### PR TITLE
Use BinaryFormatter to get bytes from object

### DIFF
--- a/Maybe/Maybe.csproj
+++ b/Maybe/Maybe.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net20;net45;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>net20;net45;netstandard1.0;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.0.79</Version>
     <Authors>Ryan McCoy</Authors>
@@ -19,13 +19,15 @@
     <PackageReleaseNotes>New support for count min sketch!</PackageReleaseNotes>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net20'">
     <PackageReference Include="LinqBridge">
       <Version>1.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+    <PackageReference Include="System.Runtime.Serialization.Json">
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/Maybe/Maybe.csproj
+++ b/Maybe/Maybe.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net20;net45;netstandard1.0;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.79</Version>
+    <Version>1.0.80</Version>
     <Authors>Ryan McCoy</Authors>
     <Company>Ryan McCoy</Company>
     <PackageId>Maybe.NET</PackageId>

--- a/Maybe/Utilities/ByteConverter.cs
+++ b/Maybe/Utilities/ByteConverter.cs
@@ -1,10 +1,37 @@
-﻿using System.Text;
-using Newtonsoft.Json;
+﻿using System.IO;
+using System.Text;
 
 namespace Maybe.Utilities
 {
     public static class ByteConverter
     {
-        public static byte[] ConvertToByteArray(object item) => item == null ? null : Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(item));
+        public static byte[] ConvertToByteArray(object item)
+        {
+            if (item == null)
+            {
+                return null;
+            }
+            else
+            {
+#if NETSTANDARD1_0
+                /*
+                 * NETSTANDARD1_* didn't implement BinaryFromatter class
+                 * Use DataContractJsonSerializer instead for serialization
+                 */
+                var formatter = new System.Runtime.Serialization.Json.DataContractJsonSerializer(item.GetType());
+#else
+                var formatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+#endif
+                using (var stream = new MemoryStream())
+                {
+#if NETSTANDARD1_0
+                    formatter.WriteObject(stream, item);
+#else
+                    formatter.Serialize(stream, item);
+#endif
+                    return stream.ToArray();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Use `BinaryFormatter` to get bytes from object for acceleration & getting rid of hard dependency to `Newtonsoft.Json` package.