### PR TITLE
#1 Allow bloom filters to be serialized/deserialized

### DIFF
--- a/Maybe.Test/BloomFilter/BloomFilterTests.cs
+++ b/Maybe.Test/BloomFilter/BloomFilterTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
 using Maybe.BloomFilter;
 using Xunit;
 
@@ -53,12 +56,28 @@ namespace Maybe.Test.BloomFilter
             Assert.Equal(3d/250d, filter.FillRatio);
         }
 
+        [Fact]
+        public void Contains_WhenItemHasBeenAdded_AndFilterHasBeenSerializedAndUnserialized_ShouldReturnTrue()
+        {
+            using (var stream = new MemoryStream())
+            {
+                var filterOld = BloomFilter<int>.Create(50, 0.02);
+                filterOld.Add(42);
+                IFormatter formatter = new BinaryFormatter();
+                formatter.Serialize(stream, filterOld);
+                stream.Flush();
+                stream.Position = 0;
+                BloomFilter<int> filterNew = (BloomFilter<int>)formatter.Deserialize(stream);
+                Assert.True(filterNew.Contains(42));
+            }
+        }
+
         private class MyTestBloomFilter<T> : BloomFilter<T>
         {
             public MyTestBloomFilter(int bitArraySize, int numHashes)
                 : base(bitArraySize, numHashes)
             {
-                
+
             }
         }
     }

--- a/Maybe.Test/BloomFilter/CountingBloomFilterTests.cs
+++ b/Maybe.Test/BloomFilter/CountingBloomFilterTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
 using Maybe.BloomFilter;
 using Xunit;
 
@@ -87,6 +90,22 @@ namespace Maybe.Test.BloomFilter
             }
             filter.Add(42); // one additional add to attempt to roll over byte.maxvalue
             Assert.True(filter.Contains(42));
+        }
+
+        [Fact]
+        public void Contains_WhenItemHasBeenAdded_AndFilterHasBeenSerializedAndUnserialized_ShouldReturnTrue()
+        {
+            using (var stream = new MemoryStream())
+            {
+                var filterOld = CountingBloomFilter<int>.Create(50, 0.02);
+                filterOld.Add(42);
+                IFormatter formatter = new BinaryFormatter();
+                formatter.Serialize(stream, filterOld);
+                stream.Flush();
+                stream.Position = 0;
+                CountingBloomFilter<int> filterNew = (CountingBloomFilter<int>)formatter.Deserialize(stream);
+                Assert.True(filterNew.Contains(42));
+            }
         }
 
         private class MyTestBloomFilter<T> : CountingBloomFilter<T>

--- a/Maybe.Test/BloomFilter/ScalableBloomFilterTests.cs
+++ b/Maybe.Test/BloomFilter/ScalableBloomFilterTests.cs
@@ -1,4 +1,7 @@
 ﻿using Maybe.BloomFilter;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
 using Xunit;
 
 namespace Maybe.Test.BloomFilter
@@ -29,6 +32,22 @@ namespace Maybe.Test.BloomFilter
                 filter.Add(i);
             }
             Assert.Equal(2, filter.NumberFilters);
+        }
+
+        [Fact]
+        public void Contains_WhenItemHasBeenAdded_AndFilterHasBeenSerializedAndUnserialized_ShouldReturnTrue()
+        {
+            using (var stream = new MemoryStream())
+            {
+                var filterOld = new ScalableBloomFilter<int>(0.02);
+                filterOld.Add(42);
+                IFormatter formatter = new BinaryFormatter();
+                formatter.Serialize(stream, filterOld);
+                stream.Flush();
+                stream.Position = 0;
+                ScalableBloomFilter<int> filterNew = (ScalableBloomFilter<int>)formatter.Deserialize(stream);
+                Assert.True(filterNew.Contains(42));
+            }
         }
     }
 }

--- a/Maybe/BloomFilter/BloomFilter.cs
+++ b/Maybe/BloomFilter/BloomFilter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 namespace Maybe.BloomFilter
 {
+    [Serializable]
     public class BloomFilter<T> : BloomFilterBase<T>
     {
         private readonly BitArray _collectionState;

--- a/Maybe/BloomFilter/BloomFilterBase.cs
+++ b/Maybe/BloomFilter/BloomFilterBase.cs
@@ -3,6 +3,7 @@ using Maybe.Utilities;
 
 namespace Maybe.BloomFilter
 {
+    [Serializable]
     public abstract class BloomFilterBase<T> : IBloomFilter<T>
     {
         protected int NumberHashes;

--- a/Maybe/BloomFilter/CountingBloomFilter.cs
+++ b/Maybe/BloomFilter/CountingBloomFilter.cs
@@ -7,6 +7,7 @@ namespace Maybe.BloomFilter
     /// A bloom filter modified to store counters and allow elements to be removed from the collection.
     /// </summary>
     /// <typeparam name="T">The type of item to be stored in the collection</typeparam>
+    [Serializable]
     public class CountingBloomFilter<T> : BloomFilterBase<T>
     {
         private readonly byte[] _collectionState;

--- a/Maybe/BloomFilter/ScalableBloomFilter.cs
+++ b/Maybe/BloomFilter/ScalableBloomFilter.cs
@@ -7,6 +7,7 @@ namespace Maybe.BloomFilter
     /// <summary>
     /// Represents a composite bloom filter, which will create many internal bloom filters to hold more values without increasing expected error rate.
     /// </summary>
+    [Serializable]
     public class ScalableBloomFilter<T> : IBloomFilter<T>
     {
         public const int MinimumCapacity = 50;


### PR DESCRIPTION
Feature request:
Allow serialization of bloom filters for quick startups after application was down.

Rebuilding of big filters might take much time and be unnecessary